### PR TITLE
test(secrets): fix key rotation tests to use persistent temp config file

### DIFF
--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -1855,9 +1855,10 @@ jwt_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
         };
         config.profiles.insert(profile_name.clone(), profile);
         config.secrets.key_rotation_interval_days = Some(30);
-        let temp_file = tempfile::NamedTempFile::new().unwrap();
-        config.save_to_file(temp_file.path()).unwrap();
-        std::env::set_var("ORDINATOR_CONFIG", temp_file.path());
+        let temp_dir = tempfile::tempdir().unwrap();
+        let config_path = temp_dir.path().join("ordinator.toml");
+        config.save_to_file(&config_path).unwrap();
+        std::env::set_var("ORDINATOR_CONFIG", &config_path);
         let result = super::check_key_rotation_needed(&profile_name).unwrap();
         assert!(result.is_some());
         let msg = result.unwrap();


### PR DESCRIPTION
CHANGES MADE:
- Use tempfile tempdir and a config file inside it for test_check_key_rotation_needed_old_key.
- Ensures the config file persists for the duration of the test, preventing intermittent failures due to temp file deletion.
- No production logic changed, only test reliability improved.

TESTING:
- All tests pass locally (cargo test --all-targets --all-features).
- No impact on production code, only test code changed.

COMPLETION STATEMENT:
This completes the test reliability fix for secrets key rotation and prepares for further test improvements or refactoring.